### PR TITLE
refactor LoSImportantValues

### DIFF
--- a/include/viewshed/losimportantvalues.h
+++ b/include/viewshed/losimportantvalues.h
@@ -18,16 +18,16 @@ namespace viewshed
 
         void reset();
 
-        double mMaxGradientBefore = -180;
-        double mMaxGradient = -180;
-        int mIndexMaxGradientBefore = -1;
-        int mIndexMaxGradient = -1;
-        int mIndexHorizonBefore = -1;
-        int mIndexHorizon = -1;
-        int mCountHorizonBefore = 0;
-        int mCountHorizon = 0;
-        bool mHorizon = false;
-        int mTargetIndex = -1;
+        double maxGradientBefore = -180;
+        double maxGradient = -180;
+        int indexMaxGradientBefore = -1;
+        int indexMaxGradient = -1;
+        int indexHorizonBefore = -1;
+        int indexHorizon = -1;
+        int countHorizonBefore = 0;
+        int countHorizon = 0;
+        bool targetHorizon = false;
+        int targetIndex = -1;
 
         /**
          * @brief Is there a horizon between view point and target point?

--- a/src/library/los/losevaluator.cpp
+++ b/src/library/los/losevaluator.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<AbstractViewshedAlgorithm> LoSEvaluator::algorithmAt( int i ) { 
 void LoSEvaluator::parseNodes()
 {
 
-    mLosValues->mTargetIndex = mLos->targetIndex();
+    mLosValues->targetIndex = mLos->targetIndex();
 
     double snGradient;
 
@@ -33,50 +33,50 @@ void LoSEvaluator::parseNodes()
             // is current PoI horizon?
             if ( i == mLos->targetPointIndex() )
             {
-                if ( mLos->gradient( i + 1 ) < snGradient && mLosValues->mMaxGradientBefore < snGradient )
+                if ( mLos->gradient( i + 1 ) < snGradient && mLosValues->maxGradientBefore < snGradient )
                 {
-                    mLosValues->mHorizon = true;
+                    mLosValues->targetHorizon = true;
                 }
             }
 
             // is LoSNode horizon before PoI?
             if ( mLos->distance( i + 1 ) <= mLos->targetDistance() )
             {
-                if ( mLosValues->mMaxGradientBefore < snGradient && mLos->gradient( i + 1 ) < snGradient )
+                if ( mLosValues->maxGradientBefore < snGradient && mLos->gradient( i + 1 ) < snGradient )
                 {
-                    mLosValues->mIndexHorizonBefore = i;
-                    mLosValues->mCountHorizonBefore++;
+                    mLosValues->indexHorizonBefore = i;
+                    mLosValues->countHorizonBefore++;
                 }
             }
 
             // is this LoSNode horizon?
-            if ( mLosValues->mMaxGradient < snGradient && mLos->gradient( i + 1 ) < snGradient )
+            if ( mLosValues->maxGradient < snGradient && mLos->gradient( i + 1 ) < snGradient )
             {
-                mLosValues->mIndexHorizon = i;
-                mLosValues->mCountHorizon++;
+                mLosValues->indexHorizon = i;
+                mLosValues->countHorizon++;
             }
         }
 
         if ( mLos->distance( i ) < mLos->targetDistance() )
         {
-            if ( mLosValues->mMaxGradientBefore < snGradient )
+            if ( mLosValues->maxGradientBefore < snGradient )
             {
-                mLosValues->mMaxGradientBefore = snGradient;
-                mLosValues->mIndexMaxGradientBefore = i;
+                mLosValues->maxGradientBefore = snGradient;
+                mLosValues->indexMaxGradientBefore = i;
             }
         }
 
-        if ( mLosValues->mMaxGradient < snGradient )
+        if ( mLosValues->maxGradient < snGradient )
         {
-            mLosValues->mMaxGradient = snGradient;
-            mLosValues->mIndexMaxGradient = i;
+            mLosValues->maxGradient = snGradient;
+            mLosValues->indexMaxGradient = i;
         }
     }
 
     // if max gradient is behind global horizon, move global horizon
-    if ( mLosValues->mIndexHorizon < mLosValues->mIndexMaxGradient )
+    if ( mLosValues->indexHorizon < mLosValues->indexMaxGradient )
     {
-        mLosValues->mIndexHorizon = mLosValues->mIndexMaxGradient;
+        mLosValues->indexHorizon = mLosValues->indexMaxGradient;
     }
 
     mAlreadyParsed = true;

--- a/src/library/structures/losimportantvalues.cpp
+++ b/src/library/structures/losimportantvalues.cpp
@@ -6,28 +6,28 @@ LoSImportantValues::LoSImportantValues() { reset(); }
 
 void LoSImportantValues::reset()
 {
-    mMaxGradientBefore = -180;
-    mMaxGradient = -180;
-    mIndexMaxGradientBefore = -1;
-    mIndexMaxGradient = -1;
-    mIndexHorizonBefore = -1;
-    mIndexHorizon = -1;
-    mCountHorizonBefore = 0;
-    mCountHorizon = 0;
-    mHorizon = false;
+    maxGradientBefore = -180;
+    maxGradient = -180;
+    indexMaxGradientBefore = -1;
+    indexMaxGradient = -1;
+    indexHorizonBefore = -1;
+    indexHorizon = -1;
+    countHorizonBefore = 0;
+    countHorizon = 0;
+    targetHorizon = false;
 }
 
-bool LoSImportantValues::horizonBeforeExist() { return mIndexHorizonBefore != -1; }
+bool LoSImportantValues::horizonBeforeExist() { return indexHorizonBefore != -1; }
 
-bool LoSImportantValues::horizonExist() { return mIndexHorizon != -1; }
+bool LoSImportantValues::horizonExist() { return indexHorizon != -1; }
 
-bool LoSImportantValues::isTargetHorizon() { return mHorizon; }
+bool LoSImportantValues::isTargetHorizon() { return targetHorizon; }
 
 bool LoSImportantValues::isTargetGlobalHorizon()
 {
     if ( horizonExist() )
     {
-        return mIndexHorizon == mTargetIndex;
+        return indexHorizon == targetIndex;
     }
     return false;
 }

--- a/src/library/visibility_algorithms/angledifferencetoglobalhorizon.cpp
+++ b/src/library/visibility_algorithms/angledifferencetoglobalhorizon.cpp
@@ -17,7 +17,7 @@ double AngleDifferenceToGlobalHorizon::result( std::shared_ptr<LoSImportantValue
     double difference;
     if ( losValues->horizonExist() )
     {
-        difference = los->targetGradient() - los->gradient( losValues->mIndexHorizon );
+        difference = los->targetGradient() - los->gradient( losValues->indexHorizon );
     }
     else
     {
@@ -30,7 +30,7 @@ double AngleDifferenceToGlobalHorizon::result( std::shared_ptr<LoSImportantValue
     }
     else
     {
-        if ( los->targetGradient() < losValues->mMaxGradientBefore )
+        if ( los->targetGradient() < losValues->maxGradientBefore )
             return mInvisibleValue;
         else
             return difference;

--- a/src/library/visibility_algorithms/angledifferencetolocalhorizon.cpp
+++ b/src/library/visibility_algorithms/angledifferencetolocalhorizon.cpp
@@ -17,7 +17,7 @@ double AngleDifferenceToLocalHorizon::result( std::shared_ptr<LoSImportantValues
     double difference;
     if ( losValues->horizonBeforeExist() )
     {
-        difference = los->targetGradient() - los->gradient( losValues->mIndexHorizonBefore );
+        difference = los->targetGradient() - los->gradient( losValues->indexHorizonBefore );
     }
     else
     {
@@ -30,7 +30,7 @@ double AngleDifferenceToLocalHorizon::result( std::shared_ptr<LoSImportantValues
     }
     else
     {
-        if ( los->targetGradient() < losValues->mMaxGradientBefore )
+        if ( los->targetGradient() < losValues->maxGradientBefore )
             return mInvisibleValue;
         else
             return difference;

--- a/src/library/visibility_algorithms/boolean.cpp
+++ b/src/library/visibility_algorithms/boolean.cpp
@@ -11,7 +11,7 @@ Boolean::Boolean( double visible, double invisible, double pointValue )
 
 double Boolean::result( std::shared_ptr<LoSImportantValues> losValues, std::shared_ptr<AbstractLoS> los )
 {
-    if ( losValues->mMaxGradientBefore < los->targetGradient() )
+    if ( losValues->maxGradientBefore < los->targetGradient() )
         return mVisibile;
     else
         return mInvisibile;

--- a/src/library/visibility_algorithms/distanceglobalhorizon.cpp
+++ b/src/library/visibility_algorithms/distanceglobalhorizon.cpp
@@ -10,7 +10,7 @@ double DistanceGlobalHorizon::result( std::shared_ptr<LoSImportantValues> losVal
 {
     if ( losValues->horizonExist() )
     {
-        return los->targetDistance() - los->distance( losValues->mIndexHorizon );
+        return los->targetDistance() - los->distance( losValues->indexHorizon );
     }
     else
     {

--- a/src/library/visibility_algorithms/distancelocalhorizon.cpp
+++ b/src/library/visibility_algorithms/distancelocalhorizon.cpp
@@ -10,7 +10,7 @@ double DistanceLocalHorizon::result( std::shared_ptr<LoSImportantValues> losValu
 {
     if ( losValues->horizonBeforeExist() )
     {
-        return los->targetDistance() - los->distance( losValues->mIndexHorizonBefore );
+        return los->targetDistance() - los->distance( losValues->indexHorizonBefore );
     }
     else
     {

--- a/src/library/visibility_algorithms/elevationdifferencetoglobalhorizon.cpp
+++ b/src/library/visibility_algorithms/elevationdifferencetoglobalhorizon.cpp
@@ -21,7 +21,7 @@ double ElevationDifferenceToGlobalHorizon::result( std::shared_ptr<LoSImportantV
 
     if ( losValues->horizonExist() )
     {
-        change = std::tan( ( M_PI / 180 ) * los->gradient( losValues->mIndexHorizon ) ) * los->targetDistance();
+        change = std::tan( ( M_PI / 180 ) * los->gradient( losValues->indexHorizon ) ) * los->targetDistance();
         difference = los->targetElevation() - ( los->vp()->totalElevation() + change );
     }
     else
@@ -35,7 +35,7 @@ double ElevationDifferenceToGlobalHorizon::result( std::shared_ptr<LoSImportantV
     }
     else
     {
-        if ( los->targetGradient() < losValues->mMaxGradientBefore )
+        if ( los->targetGradient() < losValues->maxGradientBefore )
             return mInvisibleValue;
         else
             return difference;

--- a/src/library/visibility_algorithms/elevationdifferencetolocalhorizon.cpp
+++ b/src/library/visibility_algorithms/elevationdifferencetolocalhorizon.cpp
@@ -20,7 +20,7 @@ double ElevationDifferenceToLocalHorizon::result( std::shared_ptr<LoSImportantVa
 
     if ( losValues->horizonBeforeExist() )
     {
-        change = std::tan( ( M_PI / 180 ) * losValues->mMaxGradientBefore ) * los->targetDistance();
+        change = std::tan( ( M_PI / 180 ) * losValues->maxGradientBefore ) * los->targetDistance();
         difference = los->targetElevation() - ( los->vp()->totalElevation() + change );
     }
     else
@@ -34,7 +34,7 @@ double ElevationDifferenceToLocalHorizon::result( std::shared_ptr<LoSImportantVa
     }
     else
     {
-        if ( los->targetGradient() < losValues->mMaxGradientBefore )
+        if ( los->targetGradient() < losValues->maxGradientBefore )
             return mInvisibleValue;
         else
             return difference;

--- a/src/library/visibility_algorithms/fuzzy.cpp
+++ b/src/library/visibility_algorithms/fuzzy.cpp
@@ -14,16 +14,16 @@ FuzzyVisibility::FuzzyVisibility( double clearVisibility, double halfDropout, bo
 
 double FuzzyVisibility::result( std::shared_ptr<LoSImportantValues> losValues, std::shared_ptr<AbstractLoS> los )
 {
-    if ( losValues->mMaxGradientBefore > los->targetGradient() )
+    if ( losValues->maxGradientBefore > los->targetGradient() )
     {
         return mNotVisible;
     }
 
-    double distance = los->distance( losValues->mTargetIndex );
+    double distance = los->distance( losValues->targetIndex );
 
     if ( mVerticalDistance )
     {
-        distance = sqrt( pow( los->distance( losValues->mTargetIndex ), 2 ) +
+        distance = sqrt( pow( los->distance( losValues->targetIndex ), 2 ) +
                          pow( los->vp()->totalElevation() - los->targetElevation(), 2 ) );
     }
 

--- a/src/library/visibility_algorithms/horizonscount.cpp
+++ b/src/library/visibility_algorithms/horizonscount.cpp
@@ -12,17 +12,17 @@ HorizonsCount::HorizonsCount( bool beforeTarget, bool onlyVisible, double invisi
 
 double HorizonsCount::result( std::shared_ptr<LoSImportantValues> losValues, std::shared_ptr<AbstractLoS> los )
 {
-    if ( mOnlyVisible && losValues->mMaxGradientBefore > los->targetGradient() )
+    if ( mOnlyVisible && losValues->maxGradientBefore > los->targetGradient() )
     {
         return mInvisibleValue;
     }
 
     if ( mBeforeTarget )
     {
-        return losValues->mCountHorizonBefore;
+        return losValues->countHorizonBefore;
     }
 
-    return losValues->mCountHorizon - losValues->mCountHorizonBefore;
+    return losValues->countHorizon - losValues->countHorizonBefore;
 }
 
 const QString HorizonsCount::name()

--- a/src/library/visibility_algorithms/slopetoviewangle.cpp
+++ b/src/library/visibility_algorithms/slopetoviewangle.cpp
@@ -24,7 +24,7 @@ double LoSSlopeToViewAngle::result( std::shared_ptr<LoSImportantValues> losValue
                                               ( los->targetDistance() - los->distance( los->targetIndex() - 1 ) ) );
     }
 
-    if ( losValues->mMaxGradientBefore < los->targetGradient() )
+    if ( losValues->maxGradientBefore < los->targetGradient() )
         return gradientDiff - los->targetGradient();
     else
         return mInvisibile;

--- a/src/library/visibility_algorithms/viewangle.cpp
+++ b/src/library/visibility_algorithms/viewangle.cpp
@@ -13,7 +13,7 @@ double ViewAngle::result( std::shared_ptr<LoSImportantValues> losValues, std::sh
 {
     if ( mOnlyVisible )
     {
-        if ( los->targetGradient() <= losValues->mMaxGradientBefore )
+        if ( los->targetGradient() <= losValues->maxGradientBefore )
             return mInvisibleValue;
     }
 


### PR DESCRIPTION
 rename public variables, because they are directly accessed